### PR TITLE
Replacing lasagne.utils.concatenate for theano.tensor.concatenate

### DIFF
--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -415,17 +415,17 @@ class LSTMLayer(Layer):
 
         # Stack input to gate weight matrices into a (num_inputs, 4*num_units)
         # matrix, which speeds up computation
-        self.W_in_to_gates = utils.concatenate(
+        self.W_in_to_gates = T.concatenate(
             [self.W_in_to_ingate, self.W_in_to_forgetgate,
             self.W_in_to_cell, self.W_in_to_outgate], axis=1)
 
         # Same for hidden to gate weight matrices
-        self.W_hid_to_gates = utils.concatenate(
+        self.W_hid_to_gates = T.concatenate(
             [self.W_hid_to_ingate, self.W_hid_to_forgetgate,
             self.W_hid_to_cell, self.W_hid_to_outgate], axis=1)
 
         # Stack gate biases into a (4*num_units) vector
-        self.b_gates = utils.concatenate(
+        self.b_gates = T.concatenate(
             [self.b_ingate, self.b_forgetgate,
             self.b_cell, self.b_outgate], axis=0)
 


### PR DESCRIPTION
As we can see here:

def concatenate(tensor_list, axis=0):
    """
    This function was used to work around a deficiency in Theano's
    `theano.tensor.concatenate` (the inverse operation, splitting, was not
    available on GPU). As of 2015-02-25, this deficiency has been removed,
    so this workaround is not needed any longer and will be removed for
    Lasagne's first release. Use `theano.tensor.concatenate` instead.
    """
    import warnings
    warnings.warn("lasagne.utils.concatenate will be removed.\n"
                  "Use theano.tensor.concatenate instead.")
    return T.concatenate(tensor_list, axis)

So the change was made eliminating the warnings.
