### PR TITLE
Gru unit recurrent

### DIFF
--- a/docs/modules/layers.rst
+++ b/docs/modules/layers.rst
@@ -131,6 +131,9 @@ Layer classes: recurrent layers
 .. autoclass:: LSTMLayer
     :members:
 
+.. autoclass:: GRULayer
+    :members:
+
 :mod:`lasagne.layers.corrmm`
 ============================
 

--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -922,7 +922,8 @@ class GRULayer(Layer):
             name="W_hid_to_hidden_update")
 
         self.b_hidden_update = self.add_param(
-            b_hidden_update, (num_units,), name="b_hidden_update", regularizable=False)
+            b_hidden_update, (num_units,), name="b_hidden_update",
+            regularizable=False)
 
         self.W_in_stacked = T.concatenate(
             [self.W_in_to_resetgate, self.W_in_to_updategate,

--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -838,6 +838,24 @@ class GRULayer(Layer):
        arXiv preprint arXiv:1412.3555 (2014).
     .. [3] Alex Graves : Generating Sequences With Recurrent Neural
        Networks.
+
+    Notes
+    -----
+    The GRU units is implemented slightly differently in [1]_ and in [2]_.
+    We use the following equation to calculate the hidden update:
+
+    .. math:: \hat{h}^j_t = tanh(W\mathbf{x}_t + \mathbf{r}_t
+              \odot (U\mathbf{h_{t-1}}))^j
+
+
+    An alternative formulation is:
+
+    .. math:: \hat{h}^j_t = tanh(W\mathbf{x}_t +
+              \odot U(\mathbf{r}_t\mathbf{h_{t-1}}))^j
+
+
+    We use the first formulation because it allows us to do all matrix
+    operations in a single dot product.
     """
     def __init__(self, incoming, num_units,
                  W_in_to_resetgate=init.Normal(0.1),

--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -787,14 +787,23 @@ class GRULayer(Layer):
     num_units : int
         Number of hidden units.
     W_in_to_resetgate : Theano shared variable, numpy array or callable
+        Initializer for input-to-reset gate weight matrix
     W_hid_to_resetgate : Theano shared variable, numpy array or callable
+        Initializer for hidden-to-reset gate weight matrix
     b_resetgate : Theano shared variable, numpy array or callable
+        Initializer for the reset gate bias vector
     W_in_to_updategate : Theano shared variable, numpy array or callable
+        Initializer for input-to-update gate weight matrix
     W_hid_to_updategate : Theano shared variable, numpy array or callable
+        Initializer for hidden-to-update gate weight matrix
     b_updategate : Theano shared variable, numpy array or callable
+        Initializer for the update gate bias vector
     W_in_to_hidden_update : Theano shared variable, numpy array or callable
+        Initializer for input-to-hidden update weight matrix
     W_hid_to_hidden_update : Theano shared variable, numpy array or callable
+        Initializer for hidden-to-hidden update weight matrix
     b_hidden_update : Theano shared variable, numpy array or callable
+        Initializer for the hidden update bias vector
     nonlinearity_resetgate : callable or None
         The nonlinearity that is applied to the resetgate activations. If None
         is provided, the resetgate will be linear.

--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -51,9 +51,10 @@ class CustomRecurrentLayer(Layer):
         Layer which connects input to the hidden state.
     hidden_to_hidden : :class:`lasagne.layers.Layer`
         Layer which connects the previous hidden state to the new state.
-    nonlinearity : function
-        Nonlinearity to apply when computing new state.
-    hid_init : function, np.ndarray, theano.shared or TensorVariable
+    nonlinearity : callable or None
+        Nonlinearity to apply when computing new state. If None is provided,
+        the nonlinearity will be linear.
+    hid_init : callable, np.ndarray, theano.shared or TensorVariable
         Passing in a TensorVariable allows the user to specify
         the value of `hid_init` (:math:`h_0`). In this mode, `learn_init` is
         ignored.
@@ -272,15 +273,17 @@ class RecurrentLayer(CustomRecurrentLayer):
         The layer feeding into this layer, or the expected input shape.
     num_units : int
         Number of hidden units in the layer.
-    W_in_to_hid : function or np.ndarray or theano.shared
+    W_in_to_hid : Theano shared variable, numpy array or callable
         Initializer for input-to-hidden weight matrix.
-    W_hid_to_hid : function or np.ndarray or theano.shared
+    W_hid_to_hid : Theano shared variable, numpy array or callable
         Initializer for hidden-to-hidden weight matrix.
-    b : function or np.ndarray or theano.shared
-        Initializer for bias vector.
-    nonlinearity : function
-        Nonlinearity to apply when computing new state.
-    hid_init : function, np.ndarray, theano.shared or TensorVariable
+    b : Theano shared variable, numpy array, callable or None
+        Initializer for bias vector. If None is provided there will be no
+        biases.
+    nonlinearity : callable or None
+        Nonlinearity to apply when computing new state. If None is provided,
+        the nonlinearity will be linear.
+    hid_init : callable, np.ndarray, theano.shared or TensorVariable
         Passing in a TensorVariable allows the user to specify
         the value of `hid_init` (:math:`h_0`). In this mode `learn_init` is
         ignored.
@@ -351,51 +354,56 @@ class LSTMLayer(Layer):
         The layer feeding into this layer, or the expected input shape.
     num_units : int
         Number of hidden units in the layer.
-    W_in_to_ingate : function or np.ndarray or theano.shared
+    W_in_to_ingate : Theano shared variable, numpy array or callable
         :math:`W_{xi}`.
-    W_hid_to_ingate : function or np.ndarray or theano.shared
+    W_hid_to_ingate : Theano shared variable, numpy array or callable
         :math:`W_{hi}`.
-    W_cell_to_ingate : function or np.ndarray or theano.shared
+    W_cell_to_ingate : Theano shared variable, numpy array or callable
         :math:`W_{ci}`.
-    b_ingate : function or np.ndarray or theano.shared
+    b_ingate : Theano shared variable, numpy array or callable
         :math:`b_i`.
-    nonlinearity_ingate : function
-        :math:`\sigma`.
-    W_in_to_forgetgate : function or np.ndarray or theano.shared
+    nonlinearity_ingate : callable or None
+        The nonlinearity that is applied to the ingate activations. If None
+        is provided, the ingate will be linear.
+    W_in_to_forgetgate : Theano shared variable, numpy array or callable
         :math:`W_{xf}`.
-    W_hid_to_forgetgate : function or np.ndarray or theano.shared
+    W_hid_to_forgetgate : Theano shared variable, numpy array or callable
         :math:`W_{hf}`.
-    W_cell_to_forgetgate : function or np.ndarray or theano.shared
+    W_cell_to_forgetgate : Theano shared variable, numpy array or callable
         :math:`W_{cf}`.
-    b_forgetgate : function or np.ndarray or theano.shared
+    b_forgetgate : Theano shared variable, numpy array or callable
         :math:`b_f`.
-    nonlinearity_forgetgate : function
-        :math:`\sigma`.
-    W_in_to_cell : function or np.ndarray or theano.shared
+    nonlinearity_forgetgate : callable or None
+        The nonlinearity that is applied to the forgetgate activations. If None
+        is provided, the forgetgate will be linear.
+    W_in_to_cell : Theano shared variable, numpy array or callable
         :math:`W_{ic}`.
-    W_hid_to_cell : function or np.ndarray or theano.shared
+    W_hid_to_cell : Theano shared variable, numpy array or callable
         :math:`W_{hc}`.
-    b_cell : function or np.ndarray or theano.shared
+    b_cell : Theano shared variable, numpy array or callable
         :math:`b_c`.
-    nonlinearity_cell : function or np.ndarray or theano.shared
-        :math:`tanh`.
-    W_in_to_outgate : function or np.ndarray or theano.shared
+    nonlinearity_cell : callable or None
+        The nonlinearity that is applied to the cell activations. If None
+        is provided, the cell will use linear activations.
+    W_in_to_outgate : Theano shared variable, numpy array or callable
         :math:`W_{io}`.
-    W_hid_to_outgate : function or np.ndarray or theano.shared
+    W_hid_to_outgate : Theano shared variable, numpy array or callable
         :math:`W_{ho}`.
-    W_cell_to_outgate : function or np.ndarray or theano.shared
+    W_cell_to_outgate : Theano shared variable, numpy array or callable
         :math:`W_{co}`.
-    b_outgate : function or np.ndarray or theano.shared
+    b_outgate : Theano shared variable, numpy array or callable
         :math:`b_o`.
-    nonlinearity_outgate : function
-        :math:`\sigma`.
-    nonlinearity_out : function or np.ndarray or theano.shared
-        :math:`tanh`.
-    cell_init : function, np.ndarray, theano.shared or TensorVariable
+    nonlinearity_outgate : callable or None
+        The nonlinearity that is applied to the outgate activations. If None
+        is provided, the outgate will be linear.
+    nonlinearity_out : callable or None
+        The nonlinearity that is applied to the output. If None
+        is provided, the output will be linear.
+    cell_init : callable, np.ndarray, theano.shared or TensorVariable
         Passing in a TensorVariable allows the user to specify
         the value of `cell_init` (:math:`c_0`). In this mode `learn_init` is
         ignored for the cell state.
-    hid_init : function, np.ndarray, theano.shared or TensorVariable
+    hid_init : callable, np.ndarray, theano.shared or TensorVariable
         Passing in a TensorVariable allows the user to specify
         the value of `hid_init` (:math:`h_0`). In this mode `learn_init` is
         ignored for the hidden state.
@@ -775,23 +783,29 @@ class GRULayer(Layer):
         The layer feeding into this layer, or the expected input shape.
     num_units : int
         Number of hidden units.
-    W_in_to_resetgate : function or np.ndarray or theano.shared
-    W_hid_to_resetgate : function or np.ndarray or theano.shared
-    b_resetgate : function or np.ndarray or theano.shared
-    W_in_to_updategate : function or np.ndarray or theano.shared
-    W_hid_to_updategate : function or np.ndarray or theano.shared
-    b_updategate : function or np.ndarray or theano.shared
-    W_in_to_cell : function or np.ndarray or theano.shared
-    W_hid_to_cell : function or np.ndarray or theano.shared
-    b_cell : function or np.ndarray or theano.shared
-    nonlinearity_resetgate : function
-    nonlinearity_updategate : function
-    nonlinearity_cell : function
-    hid_init : function, np.ndarray, theano.shared or TensorVariable
+    W_in_to_resetgate : Theano shared variable, numpy array or callable
+    W_hid_to_resetgate : Theano shared variable, numpy array or callable
+    b_resetgate : Theano shared variable, numpy array or callable
+    W_in_to_updategate : Theano shared variable, numpy array or callable
+    W_hid_to_updategate : Theano shared variable, numpy array or callable
+    b_updategate : Theano shared variable, numpy array or callable
+    W_in_to_cell : Theano shared variable, numpy array or callable
+    W_hid_to_cell : Theano shared variable, numpy array or callable
+    b_cell : Theano shared variable, numpy array or callable
+    nonlinearity_resetgate : callable or None
+        The nonlinearity that is applied to the resetgate activations. If None
+        is provided, the resetgate will be linear.
+    nonlinearity_updategate : callable or None
+        The nonlinearity that is applied to the updategate activations. If None
+        is provided, the updategate will be linear.
+    nonlinearity_hid : callable or None
+        The nonlinearity that is applied to the hidden activations. If None
+        is provided, the hidden state will be linear.
+    hid_init : callable, np.ndarray, theano.shared or TensorVariable
         Passing in a TensorVariable allows the user to specify
         the value of `hid_init` (:math:`h_0`). In this mode, `learn_init` is
         ignored.
-    backwards : boolean
+    backwards : bool
         If True, process the sequence backwards and then reverse the
         output again such that the output from the layer is always
         from :math:`x_1` to :math:`x_n`.
@@ -834,7 +848,7 @@ class GRULayer(Layer):
                  b_cell=init.Constant(0.),
                  nonlinearity_resetgate=nonlinearities.sigmoid,
                  nonlinearity_updategate=nonlinearities.sigmoid,
-                 nonlinearity_cell=nonlinearities.tanh,
+                 nonlinearity_hid=nonlinearities.tanh,
                  hid_init=init.Constant(0.),
                  learn_init=True,
                  backwards=False,
@@ -855,10 +869,10 @@ class GRULayer(Layer):
         else:
             self.nonlinearity_updategate = nonlinearity_updategate
 
-        if nonlinearity_cell is None:
-            self.nonlinearity_cell = nonlinearities.identity
+        if nonlinearity_hid is None:
+            self.nonlinearity_hid = nonlinearities.identity
         else:
-            self.nonlinearity_cell = nonlinearity_cell
+            self.nonlinearity_hid = nonlinearity_hid
 
         self.learn_init = learn_init
         self.num_units = num_units
@@ -998,7 +1012,7 @@ class GRULayer(Layer):
             if self.grad_clipping is not False:
                 cell = theano.gradient.grad_clip(
                     cell, -self.grad_clipping, self.grad_clipping)
-            cell = self.nonlinearity_cell(cell)
+            cell = self.nonlinearity_hid(cell)
 
             hid = (1-updategate)*hid_previous + updategate*cell
             return hid

--- a/lasagne/layers/recurrent.py
+++ b/lasagne/layers/recurrent.py
@@ -885,9 +885,7 @@ class GRULayer(Layer):
         self.unroll_scan = unroll_scan
 
         # Input dimensionality is the output dimensionality of the input layer
-        num_batch = self.input_shape[0]
         num_inputs = np.prod(self.input_shape[2:])
-        self.num_inputs = num_inputs
 
         self.W_in_to_updategate = self.add_param(
             W_in_to_updategate, (num_inputs, num_units),

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -1,6 +1,6 @@
 import pytest
 from lasagne.layers import RecurrentLayer, LSTMLayer, CustomRecurrentLayer
-from lasagne.layers import InputLayer, DenseLayer
+from lasagne.layers import InputLayer, DenseLayer, GRULayer
 from lasagne.layers import helper
 import theano
 import theano.tensor as T
@@ -211,12 +211,9 @@ def test_recurrent_unroll_scan_bck():
     num_batch, seq_len, n_features1 = 2, 3, 4
     num_units = 2
     x = T.tensor3()
-    mask = T.matrix()
     in_shp = (num_batch, seq_len, n_features1)
     l_inp = InputLayer(in_shp)
-
     x_in = np.random.random(in_shp).astype('float32')
-    mask_in = np.ones(in_shp[:2]).astype('float32')
 
     # need to set random seed.
     np.random.seed(1234)
@@ -225,10 +222,10 @@ def test_recurrent_unroll_scan_bck():
     np.random.seed(1234)
     l_rec_unroll = RecurrentLayer(l_inp, num_units=num_units, backwards=True,
                                   unroll_scan=True)
-    l_out_scan = helper.get_output(l_rec_scan, x, mask=mask)
-    l_out_unroll = helper.get_output(l_rec_unroll, x, mask=mask)
-    f_rec = theano.function([x, mask], [l_out_scan, l_out_unroll])
-    f_out_scan, f_out_unroll = f_rec(x_in, mask_in)
+    l_out_scan = helper.get_output(l_rec_scan, x)
+    l_out_unroll = helper.get_output(l_rec_unroll, x)
+    f_rec = theano.function([x], [l_out_scan, l_out_unroll])
+    f_out_scan, f_out_unroll = f_rec(x_in)
 
     np.testing.assert_almost_equal(f_out_scan, f_out_unroll)
 
@@ -442,12 +439,10 @@ def test_lstm_unroll_scan_bck():
     num_batch, seq_len, n_features1 = 2, 3, 4
     num_units = 2
     x = T.tensor3()
-    mask = T.matrix()
     in_shp = (num_batch, seq_len, n_features1)
     l_inp = InputLayer(in_shp)
 
     x_in = np.random.random(in_shp).astype('float32')
-    mask_in = np.ones(in_shp[:2]).astype('float32')
 
     # need to set random seed.
     np.random.seed(1234)
@@ -463,9 +458,219 @@ def test_lstm_unroll_scan_bck():
                                 nonlinearity_ingate=None,
                                 nonlinearity_out=None,
                                 nonlinearity_outgate=None)
-    l_out_scan = helper.get_output(l_lstm_scan, x, mask=mask)
-    l_out_unrolled = helper.get_output(l_lstm_unrolled, x, mask=mask)
-    f_lstm = theano.function([x, mask], [l_out_scan, l_out_unrolled])
-    f_out_scan, f_out_unroll = f_lstm(x_in, mask_in)
+    l_out_scan = helper.get_output(l_lstm_scan, x)
+    l_out_unrolled = helper.get_output(l_lstm_unrolled, x)
+    f_lstm = theano.function([x], [l_out_scan, l_out_unrolled])
+    f_out_scan, f_out_unroll = f_lstm(x_in)
 
     np.testing.assert_almost_equal(f_out_scan, f_out_unroll)
+
+
+def test_gru_return_shape():
+    num_batch, seq_len, n_features1, n_features2 = 5, 3, 10, 11
+    num_units = 6
+    x = T.tensor4()
+    in_shp = (num_batch, seq_len, n_features1, n_features2)
+    l_inp = InputLayer(in_shp)
+    l_rec = GRULayer(l_inp, num_units=num_units)
+
+    x_in = np.random.random(in_shp).astype('float32')
+    l_out = helper.get_output(l_rec, x)
+    f_rec = theano.function([x], l_out)
+    f_out = f_rec(x_in)
+
+    assert helper.get_output_shape(l_rec, x_in.shape) == f_out.shape
+    assert f_out.shape == (num_batch, seq_len, num_units)
+
+
+def test_gru_grad():
+    num_batch, seq_len, n_features = 5, 3, 10
+    num_units = 6
+    x = T.tensor3()
+    mask = T.matrix()
+    l_inp = InputLayer((num_batch, seq_len, n_features))
+    l_gru = GRULayer(l_inp,
+                     num_units=num_units)
+    l_out = helper.get_output(l_gru, x, mask=mask)
+    g = T.grad(T.mean(l_out), lasagne.layers.get_all_params(l_gru))
+    assert isinstance(g, (list, tuple))
+
+
+def test_gru_nparams_learn_init_false():
+    l_inp = InputLayer((2, 2, 3))
+    l_gru = GRULayer(l_inp, 5, learn_init=False)
+
+    # 3*n_gates
+    # the 3 is because we have  hid_to_gate, in_to_gate and bias for each gate
+    assert len(lasagne.layers.get_all_params(l_gru, trainable=True)) == 9
+
+    # bias params(3) + hid_init
+    assert len(lasagne.layers.get_all_params(l_gru, regularizable=False)) == 4
+
+
+def test_gru_nparams_learn_init_true():
+    l_inp = InputLayer((2, 2, 3))
+    l_gru = GRULayer(l_inp, 5, learn_init=True)
+
+    # 3*n_gates + hid_init
+    # the 3 is because we have  hid_to_gate, in_to_gate and bias for each gate
+    assert len(lasagne.layers.get_all_params(l_gru, trainable=True)) == 10
+
+    # bias params(3) + init params(1)
+    assert len(lasagne.layers.get_all_params(l_gru, regularizable=False)) == 4
+
+
+def test_gru_tensor_init():
+    # check if passing in TensorVariables to cell_init and hid_init works
+    num_units = 5
+    batch_size = 3
+    seq_len = 2
+    n_inputs = 4
+    in_shp = (batch_size, seq_len, n_inputs)
+    l_inp = InputLayer(in_shp)
+    hid_init = T.matrix()
+    x = T.tensor3()
+
+    l_lstm = GRULayer(l_inp, num_units, learn_init=True, hid_init=hid_init)
+
+    # check that the tensors are used and not overwritten
+    assert hid_init == l_lstm.hid_init
+
+    # 3*n_gates, should not return any inits
+    # the 3 is because we have  hid_to_gate, in_to_gate and bias for each gate
+    assert len(lasagne.layers.get_all_params(l_lstm, trainable=True)) == 9
+
+    # bias params(3), , should not return any inits
+    assert len(lasagne.layers.get_all_params(l_lstm, regularizable=False)) == 3
+
+    # check that it compiles and runs
+    output = lasagne.layers.get_output(l_lstm, x)
+    f = theano.function([x, hid_init], output)
+    x_test = np.ones(in_shp, dtype='float32')
+    hid_init = np.ones((batch_size, num_units), dtype='float32')
+    out = f(x_test, hid_init)
+    assert isinstance(out, np.ndarray)
+
+
+def test_gru_init_val_error():
+    # check if errors are raised when inits are non matrix tensor
+    vector = T.vector()
+    with pytest.raises(ValueError):
+        l_rec = GRULayer(InputLayer((2, 2, 3)), 5, hid_init=vector)
+
+
+def test_gru_grad_clipping():
+    # test that you can set grad_clip variable
+    x = T.tensor3()
+    l_rec = GRULayer(InputLayer((2, 2, 3)), 5, grad_clipping=1)
+    l_out = lasagne.layers.get_output(l_rec, x)
+
+
+def test_gru_bck():
+    num_batch, seq_len, n_features1 = 2, 3, 4
+    num_units = 2
+    x = T.tensor3()
+    in_shp = (num_batch, seq_len, n_features1)
+    l_inp = InputLayer(in_shp)
+
+    x_in = np.ones(in_shp).astype('float32')
+
+    # need to set random seed.
+    np.random.seed(1234)
+    l_gru_fwd = GRULayer(l_inp, num_units=num_units, backwards=False)
+    np.random.seed(1234)
+    l_gru_bck = GRULayer(l_inp, num_units=num_units, backwards=True)
+    l_out_fwd = helper.get_output(l_gru_fwd, x)
+    l_out_bck = helper.get_output(l_gru_bck, x)
+    f_lstm = theano.function([x], [l_out_fwd, l_out_bck])
+    f_out_fwd, f_out_bck = f_lstm(x_in)
+
+    # test that the backwards model reverses its final input
+    np.testing.assert_almost_equal(f_out_fwd, f_out_bck[:, ::-1])
+
+
+def test_gru_self_outvars():
+    # check that outvars are correctly stored and returned
+    num_batch, seq_len, n_features1 = 2, 3, 4
+    num_units = 2
+    x = T.tensor3()
+    in_shp = (num_batch, seq_len, n_features1)
+    l_inp = InputLayer(in_shp)
+
+    x_in = np.ones(in_shp).astype('float32')
+
+    # need to set random seed.
+    l_gru = GRULayer(l_inp, num_units=num_units, backwards=True)
+    l_out = helper.get_output(l_gru, x)
+    f_gru = theano.function([x], [l_out, l_gru.hid_out])
+    f_out, f_out_self = f_gru(x_in)
+
+    np.testing.assert_almost_equal(f_out, f_out_self)
+
+
+def test_gru_variable_input_size():
+    # that seqlen and batchsize none works
+    num_batch, n_features1 = 6, 5
+    num_units = 13
+    x = T.tensor3()
+
+    in_shp = (None, None, n_features1)
+    l_inp = InputLayer(in_shp)
+    x_in2 = np.ones((num_batch, 15, n_features1)).astype('float32')
+    x_in1 = np.ones((num_batch+1, 10, n_features1)).astype('float32')
+    l_rec = GRULayer(l_inp, num_units=num_units, backwards=False)
+    l_out = helper.get_output(l_rec, x)
+    f_rec = theano.function([x], l_out)
+    f_out1 = f_rec(x_in1)
+    f_out2 = f_rec(x_in2)
+
+
+def test_gru_unroll_scan_fwd():
+    num_batch, seq_len, n_features1 = 2, 3, 4
+    num_units = 2
+    x = T.tensor3()
+    mask = T.matrix()
+    in_shp = (num_batch, seq_len, n_features1)
+    l_inp = InputLayer(in_shp)
+
+    x_in = np.random.random(in_shp).astype('float32')
+    mask_in = np.ones(in_shp[:2]).astype('float32')
+
+    # need to set random seed.
+    np.random.seed(1234)
+    l_gru_scan = GRULayer(l_inp, num_units=num_units, backwards=False,
+                          unroll_scan=False)
+    np.random.seed(1234)
+    l_gru_unrolled = GRULayer(l_inp, num_units=num_units, backwards=False,
+                              unroll_scan=True)
+    l_out_scan = helper.get_output(l_gru_scan, x, mask=mask)
+    l_out_unrolled = helper.get_output(l_gru_unrolled, x, mask=mask)
+    f_gru = theano.function([x, mask], [l_out_scan, l_out_unrolled])
+    f_out_scan, f_out_unroll = f_gru(x_in, mask_in)
+
+    np.testing.assert_almost_equal(f_out_scan, f_out_unroll)
+
+
+def test_gru_unroll_scan_bck():
+    num_batch, seq_len, n_features1 = 2, 5, 4
+    num_units = 2
+    x = T.tensor3()
+    in_shp = (num_batch, seq_len, n_features1)
+    l_inp = InputLayer(in_shp)
+    x_in = np.random.random(in_shp).astype('float32')
+
+    # need to set random seed.
+    np.random.seed(1234)
+    l_gru_scan = GRULayer(l_inp, num_units=num_units, backwards=True,
+                          unroll_scan=False, nonlinearity_resetgate=None,
+                          nonlinearity_updategate=None,
+                          nonlinearity_cell=None)
+    np.random.seed(1234)
+    l_gru_unrolled = GRULayer(l_inp, num_units=num_units, backwards=True,
+                              unroll_scan=True, nonlinearity_resetgate=None,
+                              nonlinearity_updategate=None,
+                              nonlinearity_cell=None)
+    l_out_scan = helper.get_output(l_gru_scan, x)
+    l_out_unrolled = helper.get_output(l_gru_unrolled, x)
+    f_gru = theano.function([x], [l_out_scan, l_out_unrolled])
+    f_out_scan, f_out_unroll = f_gru(x_in)

--- a/lasagne/tests/layers/test_recurrent.py
+++ b/lasagne/tests/layers/test_recurrent.py
@@ -664,12 +664,12 @@ def test_gru_unroll_scan_bck():
     l_gru_scan = GRULayer(l_inp, num_units=num_units, backwards=True,
                           unroll_scan=False, nonlinearity_resetgate=None,
                           nonlinearity_updategate=None,
-                          nonlinearity_cell=None)
+                          nonlinearity_hid=None)
     np.random.seed(1234)
     l_gru_unrolled = GRULayer(l_inp, num_units=num_units, backwards=True,
                               unroll_scan=True, nonlinearity_resetgate=None,
                               nonlinearity_updategate=None,
-                              nonlinearity_cell=None)
+                              nonlinearity_hid=None)
     l_out_scan = helper.get_output(l_gru_scan, x)
     l_out_unrolled = helper.get_output(l_gru_unrolled, x)
     f_gru = theano.function([x], [l_out_scan, l_out_unrolled])

--- a/lasagne/utils.py
+++ b/lasagne/utils.py
@@ -337,11 +337,15 @@ def unroll_scan(fn, sequences, outputs_info, non_sequences, n_steps,
             counter = counter[::-1]
 
         output = []
-        init = outputs_info
+        prev_vals = outputs_info
         for i in counter:
-            step_input = [s[i] for s in sequences] + init + non_sequences
-            output.append(fn(*step_input))
-            init = output[-1]
+            step_input = [s[i] for s in sequences] + prev_vals + non_sequences
+            out_ = fn(*step_input)
+            if not isinstance(out_, (list, tuple)):
+                out_ = [out_]
+            output.append(out_)
+
+            prev_vals = output[-1]
 
         # iterate over each scan output and convert it to same format as scan:
         # [[output11, output12,...output1n],


### PR DESCRIPTION
- Add gru units
- Add gru tests
- fix bug in unroll_scan when fn did not return a list
- modify the unroll_scan_bck tests to run without mask
- add gru layer to docs
- While correcting the GRU docs i discovered a few erros in the docs that also applied to the other recurrent layers. These changes are included here

Note: We should cosider renamed either self.unroll_scan or utils.unroll_scan
